### PR TITLE
Retour issues sur github

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ OpenSondage is used to poll people invite for a meeting.
 ## Change done from original sources
 This package contains a custom version of Framadate (fork of OpenSondage and Studs), the sources are here: https://git.framasoft.org/framasoft/framadate/commit/2c49a9f0acdc6ee1164d3d533a35b273af30c263. You can see change in the history of the depot.
 
-## How to report a bug ?
-
-You can report an issue concerning this package on the official YunoHost bug tracker : https://dev.yunohost.org .
-
 ## Screenshot
 
 <img src="/sources/images/date.png" style="max-width:100%;" alt="Screen containing a meeting poll"/>


### PR DESCRIPTION
Suite à la décision sur les issues des applications.
https://forum.yunohost.org/t/tickets-pour-la-gestion-des-applications/2154/37

Les issues reviennent sur github.