### PR TITLE
Fix stdout.log owner

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -171,6 +171,7 @@ sudo -u "$app" php "$final_path/admin/migration.php"
 
 chown -R root: "$final_path"
 chown -R "$app": "$final_path/tpl_c"
+chown -R "$app": "$final_path/admin/stdout.log"
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/restore
+++ b/scripts/restore
@@ -73,6 +73,7 @@ ynh_system_user_create "$app"
 
 # Set permissions
 chown -R "$app": "$final_path/tpl_c"
+chown -R "$app": "$final_path/admin/stdout.log"
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -199,6 +199,7 @@ sudo -u "$app" php "$final_path/admin/migration.php"
 
 chown -R root: "$final_path"
 chown -R "$app": "$final_path/tpl_c"
+chown -R "$app": "$final_path/admin/stdout.log"
 
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
## Problem
- *I saw in my php5-fpm.log that there was a problem regarding the ownership of "stdout.log"*

*> WARNING: [pool opensondage] child 14910 said into stderr: "NOTICE: PHP message: PHP Warning:  error_log(/var/www/opensondage/app/inc/../../admin/stdout.log): failed to open stream: Permission denied in /var/www/opensondage/app/classes/Framadate/Services/LogService.php on line 21"*

## Solution
- *I have changed the file's owner to "opensondage" to fix the issue.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Josué
- **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR34%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR34%20(Official_fork)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.