### PR TITLE
Access to "adminstuds.php" when app is in public

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -183,7 +183,7 @@ if [ $is_public -eq 0 ];
 then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
-	ynh_app_setting_set "$app" protected_uris "/admin"
+	ynh_app_setting_set "$app" protected_regex "/admin/"
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 
 	ynh_store_file_checksum "$finalnginxconf"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -211,7 +211,9 @@ if [ $is_public -eq 0 ];
 then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
-	ynh_app_setting_set "$app" protected_uris "/admin"
+	ynh_app_setting_delete "$app" protected_uris
+	ynh_app_setting_set "$app" protected_regex "/admin/"
+
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 
 	ynh_store_file_checksum "$finalnginxconf"


### PR DESCRIPTION
## Problem
When the app is in public, after creating a poll, the user (if i he's not logged in) is redirected to the yunohost login panel and he can't admin his poll.

## Solution
Use `protected_regex` instead of  `protected_uris` to prevent access to "/admin/" but not "/adminstuds.php"

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [ ] **Code review** : 
- [ ] **Approval (LGTM)** : 
- [ ] **Approval (LGTM)** : 
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20-BRANCH-%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20-BRANCH-%20(Official)/) *Please replace '-BRANCH-' in this link for a PR from a local branch.*  
or  
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR-NUM-%20(Official_fork)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR-NUM-%20(Official_fork)/) *Replace '-NUM-' by the PR number in this link for a PR from a forked repository.*  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
