### PR TITLE
Access to "adminstuds.php" when app is in public

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -183,7 +183,15 @@ if [ $is_public -eq 0 ];
 then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
-	ynh_app_setting_set "$app" protected_regex "/admin/"
+	# If the app is private, viewing images stays publicly accessible.
+	if [ "$path_url" == "/" ]; then
+	    # If the path is /, clear it to prevent any error with the regex.
+	    path_url=""
+	fi
+	# Modify the domain to be used in a regex
+	domain_regex=$(echo "$domain" | sed 's@-@.@g')
+	ynh_app_setting_set $app protected_regex "$domain_regex$path_url/admin/"
+
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 
 	ynh_store_file_checksum "$finalnginxconf"

--- a/scripts/install
+++ b/scripts/install
@@ -183,7 +183,7 @@ if [ $is_public -eq 0 ];
 then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
-	ynh_app_setting_set "$app" protected_uris "/admin"
+	ynh_app_setting_set "$app" protected_regex "/admin/"
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 
 	ynh_store_file_checksum "$finalnginxconf"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -212,7 +212,15 @@ then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
 	ynh_app_setting_delete "$app" protected_uris
-	ynh_app_setting_set "$app" protected_regex "/admin/"
+
+	# If the app is private, viewing images stays publicly accessible.
+	if [ "$path_url" == "/" ]; then
+	    # If the path is /, clear it to prevent any error with the regex.
+	    path_url=""
+	fi
+	# Modify the domain to be used in a regex
+	domain_regex=$(echo "$domain" | sed 's@-@.@g')
+	ynh_app_setting_set $app protected_regex "$domain_regex$path_url/admin/"
 
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -211,7 +211,9 @@ if [ $is_public -eq 0 ];
 then
 	ynh_app_setting_set "$app" protected_uris "/"
 else
-	ynh_app_setting_set "$app" protected_uris "/admin"
+	ynh_app_setting_delete "$app" protected_uris
+	ynh_app_setting_set "$app" protected_regex "/admin/"
+
 	ynh_replace_string "	include conf.d/"  "	#include conf.d/"  "$finalnginxconf"
 
 	ynh_store_file_checksum "$finalnginxconf"


### PR DESCRIPTION
## Problem
When the app is in public, after creating a poll, the user (if i he's not logged in) is redirected to the yunohost login panel and he can't admin his poll.

## Solution
Use `protected_regex` instead of  `protected_uris` to prevent access to "/admin/" but not "/adminstuds.php"

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : JimboJoe
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/opensondage_ynh%20PR47/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/opensondage_ynh%20PR47/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
