### PR TITLE
Add explicit dependency on php-xml.

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -60,7 +60,7 @@ ynh_app_setting_set "$app" is_public "$is_public"
 # INSTALL DEPENDENCIES
 #=================================================
 
-ynh_install_app_dependencies php-fpdf
+ynh_install_app_dependencies php-fpdf php-xml
 
 #=================================================
 # CREATE A MYSQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -96,7 +96,7 @@ ynh_mysql_connect_as "$db_name" "$db_pwd" "$db_name" < ./db.sql
 #=================================================
 
 # Dependences
-ynh_install_app_dependencies php-fpdf
+ynh_install_app_dependencies php-fpdf php-xml
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION


https://github.com/YunoHost-Apps/opensondage_ynh/issues/44

## Problem
- *On a fresh yunohost php7.0-xml is not installed and it is required for opensondage.*

## Solution
- *Add php-xml as a dependency*
- *Fix #44*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-hq.yunohost.org/jenkins/job/opensondage_ynh%20PR49/badge/icon)](https://ci-apps-hq.yunohost.org/jenkins/job/opensondage_ynh%20PR49/)  
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.