### PR TITLE
Fix warnings

### DIFF
--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -431,3 +431,6 @@ chdir = __FINALPATH__
 
 php_admin_value[upload_max_filesize] = 10G
 php_admin_value[post_max_size] = 10G
+
+php_admin_value[session.cookie_httponly] = 1
+php_admin_value[date.timezone] = __TIMEZONE__

--- a/scripts/install
+++ b/scripts/install
@@ -121,6 +121,8 @@ ynh_replace_string --match_string="__ADMINMAIL__" --replace_string=$admin_mail -
 ynh_replace_string --match_string="__LANGUAGE__"  --replace_string=$language   --target_file="$config"
 ynh_replace_string --match_string="__DOMAIN__"    --replace_string=$domain     --target_file="$config"
 ynh_replace_string --match_string="__PATH__"      --replace_string=$path_url   --target_file="$config"
+timezone="$(cat /etc/timezone)"
+ynh_replace_string --match_string="__TIMEZONE__"  --replace_string=$timezone   --target_file="$config"
 
 # Calculate and store the config file checksum into the app settings
 ynh_store_file_checksum --file="$config"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -172,7 +172,8 @@ then
     ynh_replace_string --match_string="__LANGUAGE__"  --replace_string=$language   --target_file="$config"
     ynh_replace_string --match_string="__DOMAIN__"    --replace_string=$domain     --target_file="$config"
     ynh_replace_string --match_string="__PATH__"      --replace_string=$path_url   --target_file="$config"
-
+    timezone="$(cat /etc/timezone)"
+    ynh_replace_string --match_string="__TIMEZONE__"  --replace_string=$timezone   --target_file="$config"
     # Calculate and store the config file checksum into the app settings
     ynh_store_file_checksum --file="$config"
 fi


### PR DESCRIPTION
There are some warnings on the admin page (`https://<domain>/sondage/admin/check.php`)
* unset default timezone
* unset variable for session cookie protection

I tested the fixes on my server, it works fine although I didn't test the install/upgrade scripts.

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/opensondage_ynh%20PR-NUM-%20(USERNAME)/)  
